### PR TITLE
feat: Agregar colision con enemigos voladores

### DIFF
--- a/scenes/levels/enemy-wave-1.tscn
+++ b/scenes/levels/enemy-wave-1.tscn
@@ -62,13 +62,16 @@ z_as_relative = false
 curve = SubResource("Curve2D_4kdf1")
 
 [node name="PathFollow2D" type="PathFollow2D" parent="Path2D"]
-position = Vector2(1091, 0)
+position = Vector2(1273, 0)
+progress = 4672.03
 rotates = false
 script = ExtResource("2_pge05")
 
 [node name="Node2D" type="Node2D" parent="Path2D/PathFollow2D"]
 
 [node name="FlyingEnemy" parent="Path2D/PathFollow2D/Node2D" instance=ExtResource("2_4kdf1")]
+collision_layer = 64
+collision_mask = 128
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
 libraries = {

--- a/scripts/flying_enemy.gd
+++ b/scripts/flying_enemy.gd
@@ -42,7 +42,9 @@ func _on_area_entered(bullet: Area2D) -> void:
 		else:
 			hp -= 1
 			bullet.borrar.rpc() # Se elimina igual la bala para no tener penetracion de enemigos
-	
+	if bullet.has_method("take_damage"):
+		bullet.take_damage.rpc()
+
 @rpc("call_local")
 func dead():
 	self.queue_free()


### PR DESCRIPTION
## Descripción

Ahora los enemigos voladores dañan al jugador


## ¿Cómo se probó este cambio?

Se inicio el juego y se chequeo que los personajes perdian vida con los enemigos voladores


## Screenshots

No aplica.
